### PR TITLE
This PR will be done to fix some logics in MuonSFs

### DIFF
--- a/mu.h
+++ b/mu.h
@@ -72,20 +72,17 @@ public:
     {
         const GenLeptonMatch genMatch = static_cast<GenLeptonMatch>(TauMu_genMatch);
         if((genMatch != GenLeptonMatch::Muon && genMatch != GenLeptonMatch::TauMuon)) return false;
-        // if(genMatch == GenLeptonMatch::Muon || genMatch == GenLeptonMatch::TauMuon){
         // RECO
         if(source == UncSource::NUM_TrackerMuons_DEN_genTracks) return true;
-
         // ID
-        bool tightIDandIP_condition = (Muon_TightId && Muon_pfRelIso04_all<0.15);
-        bool highPtIDandIP_condition = (Muon_highPtId && Muon_tkRelIso < 0.15);
         if(source == UncSource::NUM_TightID_DEN_TrackerMuons && Muon_TightId ) return true;
         if(source == UncSource::NUM_TightID_DEN_genTracks && Muon_TightId ) return true;
-
         if(source == UncSource::NUM_HighPtID_DEN_TrackerMuons && Muon_highPtId ) return true;
         if(source == UncSource::NUM_HighPtID_DEN_genTracks && Muon_highPtId ) return true;
 
         // ISO
+        bool tightIDandIP_condition = (Muon_TightId && Muon_pfRelIso04_all<0.15);
+        bool highPtIDandIP_condition = (Muon_highPtId && Muon_tkRelIso < 0.15);
         if(source == UncSource::NUM_TightRelIso_DEN_TightIDandIPCut && tightIDandIP_condition ) return true;
         if(source == UncSource::NUM_TightRelTkIso_DEN_TrkHighPtIDandIPCut && highPtIDandIP_condition ) return true;
         // }
@@ -226,17 +223,14 @@ public:
         const GenLeptonMatch genMatch = static_cast<GenLeptonMatch>(TauMu_genMatch);
         if((genMatch != GenLeptonMatch::Muon && genMatch != GenLeptonMatch::TauMuon)) return false;
 
-        // if(genMatch == GenLeptonMatch::Muon || genMatch == GenLeptonMatch::TauMuon){
         // RECO
         if (source == UncSource::NUM_GlobalMuons_DEN_TrackerMuonProbes) return true;
         // ID
-        bool tightID_condition = (Muon_TightId && Muon_pfRelIso04_all<0.15);
-        bool highPtID_condition = (Muon_highPtId && Muon_tkRelIso < 0.15);
         if(source == UncSource::NUM_TightID_DEN_GlobalMuonProbes && Muon_TightId ) return true;
         if(source == UncSource::NUM_HighPtID_DEN_GlobalMuonProbes && Muon_highPtId ) return true;
         // ISO
+        bool highPtID_condition = (Muon_highPtId && Muon_tkRelIso < 0.15);
         if (source == UncSource::NUM_probe_TightRelTkIso_DEN_HighPtProbes && highPtID_condition ) return true;
-        // }
         return false;
     }
 

--- a/mu.h
+++ b/mu.h
@@ -72,23 +72,23 @@ public:
     {
         const GenLeptonMatch genMatch = static_cast<GenLeptonMatch>(TauMu_genMatch);
         if((genMatch != GenLeptonMatch::Muon && genMatch != GenLeptonMatch::TauMuon)) return false;
-        if(genMatch == GenLeptonMatch::Muon || genMatch == GenLeptonMatch::TauMuon){
-            // RECO
-            if(source == UncSource::NUM_TrackerMuons_DEN_genTracks) return true;
+        // if(genMatch == GenLeptonMatch::Muon || genMatch == GenLeptonMatch::TauMuon){
+        // RECO
+        if(source == UncSource::NUM_TrackerMuons_DEN_genTracks) return true;
 
-            // ID
-            bool tightID_condition = (Muon_TightId && Muon_pfRelIso04_all<0.15);
-            bool highPtID_condition = (Muon_highPtId && Muon_tkRelIso < 0.15);
-            if(source == UncSource::NUM_TightID_DEN_TrackerMuons && tightID_condition ) return true;
-            if(source == UncSource::NUM_TightID_DEN_genTracks && tightID_condition ) return true;
+        // ID
+        bool tightIDandIP_condition = (Muon_TightId && Muon_pfRelIso04_all<0.15);
+        bool highPtIDandIP_condition = (Muon_highPtId && Muon_tkRelIso < 0.15);
+        if(source == UncSource::NUM_TightID_DEN_TrackerMuons && Muon_TightId ) return true;
+        if(source == UncSource::NUM_TightID_DEN_genTracks && Muon_TightId ) return true;
 
-            if(source == UncSource::NUM_HighPtID_DEN_TrackerMuons && highPtID_condition ) return true;
-            if(source == UncSource::NUM_HighPtID_DEN_genTracks && highPtID_condition ) return true;
+        if(source == UncSource::NUM_HighPtID_DEN_TrackerMuons && Muon_highPtId ) return true;
+        if(source == UncSource::NUM_HighPtID_DEN_genTracks && Muon_highPtId ) return true;
 
-            // ISO
-            if(source == UncSource::NUM_TightRelIso_DEN_TightIDandIPCut && tightID_condition ) return true;
-            if(source == UncSource::NUM_TightRelTkIso_DEN_TrkHighPtIDandIPCut && highPtID_condition ) return true;
-        }
+        // ISO
+        if(source == UncSource::NUM_TightRelIso_DEN_TightIDandIPCut && tightIDandIP_condition ) return true;
+        if(source == UncSource::NUM_TightRelTkIso_DEN_TrkHighPtIDandIPCut && highPtIDandIP_condition ) return true;
+        // }
         // TRG
         if(source == UncSource::NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight&& muon_Pt > 26) return true;
         if(source == UncSource::NUM_IsoMu27_DEN_CutBasedIdTight_and_PFIsoTight&& muon_Pt > 29) return true;
@@ -226,17 +226,17 @@ public:
         const GenLeptonMatch genMatch = static_cast<GenLeptonMatch>(TauMu_genMatch);
         if((genMatch != GenLeptonMatch::Muon && genMatch != GenLeptonMatch::TauMuon)) return false;
 
-        if(genMatch == GenLeptonMatch::Muon || genMatch == GenLeptonMatch::TauMuon){
-            // RECO
-            if (source == UncSource::NUM_GlobalMuons_DEN_TrackerMuonProbes) return true;
-            // ID
-            bool tightID_condition = (Muon_TightId && Muon_pfRelIso04_all<0.15);
-            bool highPtID_condition = (Muon_highPtId && Muon_tkRelIso < 0.15);
-            if(source == UncSource::NUM_TightID_DEN_GlobalMuonProbes && tightID_condition ) return true;
-            if(source == UncSource::NUM_HighPtID_DEN_GlobalMuonProbes && highPtID_condition ) return true;
-            // ISO
-            if (source == UncSource::NUM_probe_TightRelTkIso_DEN_HighPtProbes && highPtID_condition ) return true;
-        }
+        // if(genMatch == GenLeptonMatch::Muon || genMatch == GenLeptonMatch::TauMuon){
+        // RECO
+        if (source == UncSource::NUM_GlobalMuons_DEN_TrackerMuonProbes) return true;
+        // ID
+        bool tightID_condition = (Muon_TightId && Muon_pfRelIso04_all<0.15);
+        bool highPtID_condition = (Muon_highPtId && Muon_tkRelIso < 0.15);
+        if(source == UncSource::NUM_TightID_DEN_GlobalMuonProbes && Muon_TightId ) return true;
+        if(source == UncSource::NUM_HighPtID_DEN_GlobalMuonProbes && Muon_highPtId ) return true;
+        // ISO
+        if (source == UncSource::NUM_probe_TightRelTkIso_DEN_HighPtProbes && highPtID_condition ) return true;
+        // }
         return false;
     }
 


### PR DESCRIPTION
When applying the muon SFs, the matching with genlepton must be required, and ok. This PR changes the conditions for the application of ID sfs (as no iso is explicitly required, only ID) and it was required too