### PR TITLE
Load trigger keys in a more safe way

### DIFF
--- a/Corrections.py
+++ b/Corrections.py
@@ -63,7 +63,7 @@ class Corrections:
         # If you run with no corrections, the code will break if you don't check that self.to_apply exists
         # I am curious if setting a new bool will increase the performance
         # I'm open to the suggestion to just do 'if self.to_apply:' instead of this new bool
-        self.corrs_to_apply = len(self.to_apply) > 0
+        self.corrs_to_apply = (self.to_apply != None)
         self.config = config
         self.sample_name = sample_name
         self.MET_type = config['met_type']

--- a/Corrections.py
+++ b/Corrections.py
@@ -60,6 +60,10 @@ class Corrections:
         self.isData = isData
         self.period = config['era']
         self.to_apply = config.get('corrections', [])
+        # If you run with no corrections, the code will break if you don't check that self.to_apply exists
+        # I am curious if setting a new bool will increase the performance
+        # I'm open to the suggestion to just do 'if self.to_apply:' instead of this new bool
+        self.corrs_to_apply = len(self.to_apply) > 0
         self.config = config
         self.sample_name = sample_name
         self.MET_type = config['met_type']
@@ -154,17 +158,18 @@ class Corrections:
 
     def applyScaleUncertainties(self, df, ana_reco_objects):
         source_dict = { central : [] }
-        if 'tauES' in self.to_apply and not self.isData:
-            df, source_dict = self.tau.getES(df, source_dict)
-        if 'eleES' in self.to_apply:
-            df, source_dict = self.ele.getES(df, source_dict)
-        if 'JEC' in self.to_apply or 'JER' in self.to_apply:
-            apply_jes = 'JEC' in self.to_apply and not self.isData
-            apply_jer = 'JER' in self.to_apply and not self.isData
-            df, source_dict = self.jet.getP4Variations(df, source_dict, apply_jer, apply_jes)
-            # df, source_dict = self.fatjet.getP4Variations(df, source_dict, 'JER' in self.to_apply, 'JEC' in self.to_apply)
-        # if 'tauES' in self.to_apply or 'JEC' in self.to_apply or 'JEC' in self.to_apply:
-        #     df, source_dict = self.met.getPFMET(df, source_dict)
+        if self.corrs_to_apply:
+            if 'tauES' in self.to_apply and not self.isData:
+                df, source_dict = self.tau.getES(df, source_dict)
+            if 'eleES' in self.to_apply:
+                df, source_dict = self.ele.getES(df, source_dict)
+            if 'JEC' in self.to_apply or 'JER' in self.to_apply:
+                apply_jes = 'JEC' in self.to_apply and not self.isData
+                apply_jer = 'JER' in self.to_apply and not self.isData
+                df, source_dict = self.jet.getP4Variations(df, source_dict, apply_jer, apply_jes)
+                # df, source_dict = self.fatjet.getP4Variations(df, source_dict, 'JER' in self.to_apply, 'JEC' in self.to_apply)
+            # if 'tauES' in self.to_apply or 'JEC' in self.to_apply or 'JEC' in self.to_apply:
+            #     df, source_dict = self.met.getPFMET(df, source_dict)
         syst_dict = { }
         for source, source_objs in source_dict.items():
             for scale in getScales(source):
@@ -243,9 +248,10 @@ class Corrections:
         df = df.Define('genWeightD', genWeight_def)
 
         all_branches = []
-        if 'pu' in self.to_apply:
-            df, pu_SF_branches = self.pu.getWeight(df)
-            all_branches.append(pu_SF_branches)
+        if self.corrs_to_apply:
+            if 'pu' in self.to_apply:
+                df, pu_SF_branches = self.pu.getWeight(df)
+                all_branches.append(pu_SF_branches)
 
         all_sources = set(itertools.chain.from_iterable(all_branches))
         if central in all_sources:
@@ -274,34 +280,38 @@ class Corrections:
                 for scale in ['Up','Down']:
                     if syst_name == f'pu{scale}' and return_variations:
                         all_weights.append(weight_out_name)
-        if 'tauID' in self.to_apply:
-            df, tau_SF_branches = self.tau.getSF(df, lepton_legs, isCentral, return_variations)
-            all_weights.extend(tau_SF_branches)
-        if 'btagShape' in self.to_apply and not self.isData:
-            df, bTagShape_SF_branches = self.btag.getBTagShapeSF(df, src_name, scale_name, isCentral, return_variations)
-            all_weights.extend(bTagShape_SF_branches)
-        if 'mu' in self.to_apply:
-            if self.mu.low_available:
-                df, lowPtmuID_SF_branches = self.mu.getLowPtMuonIDSF(df, lepton_legs, isCentral, return_variations)
-                all_weights.extend(lowPtmuID_SF_branches)
-            if self.mu.med_available:
-                df, muID_SF_branches = self.mu.getMuonIDSF(df, lepton_legs, isCentral, return_variations)
-                all_weights.extend(muID_SF_branches)
-            if self.mu.high_available:
-                df, highPtmuID_SF_branches = self.mu.getHighPtMuonIDSF(df, lepton_legs, isCentral, return_variations)
-                all_weights.extend(highPtmuID_SF_branches)
-        if 'ele' in self.to_apply:
-            df, eleID_SF_branches = self.ele.getIDSF(df, lepton_legs, isCentral, return_variations)
-            all_weights.extend(eleID_SF_branches)
-        if 'puJetID' in self.to_apply:
-            df, puJetID_SF_branches = self.puJetID.getPUJetIDEff(df, isCentral, return_variations)
-            all_weights.extend(puJetID_SF_branches)
-        if 'btagWP' in self.to_apply:
-            df, bTagWP_SF_branches = self.btag.getBTagWPSF(df, isCentral and return_variations, isCentral)
-            all_weights.extend(bTagWP_SF_branches)
-        if 'trg' in self.to_apply:
-            df, trg_SF_branches = self.trg.getEff(df, trigger_names, offline_legs, self.trigger_dict)
-            all_weights.extend(trg_SF_branches)
+        if self.corrs_to_apply:
+            if 'tauID' in self.to_apply:
+                df, tau_SF_branches = self.tau.getSF(df, lepton_legs, isCentral, return_variations)
+                all_weights.extend(tau_SF_branches)
+            if 'btagShape' in self.to_apply and not self.isData:
+                df, bTagShape_SF_branches = self.btag.getBTagShapeSF(df, src_name, scale_name, isCentral, return_variations)
+                all_weights.extend(bTagShape_SF_branches)
+            if 'mu' in self.to_apply:
+                if self.mu.low_available:
+                    df, lowPtmuID_SF_branches = self.mu.getLowPtMuonIDSF(df, lepton_legs, isCentral, return_variations)
+                    all_weights.extend(lowPtmuID_SF_branches)
+                if self.mu.med_available:
+                    df, muID_SF_branches = self.mu.getMuonIDSF(df, lepton_legs, isCentral, return_variations)
+                    all_weights.extend(muID_SF_branches)
+                if self.mu.high_available:
+                    df, highPtmuID_SF_branches = self.mu.getHighPtMuonIDSF(df, lepton_legs, isCentral, return_variations)
+                    all_weights.extend(highPtmuID_SF_branches)
+            if 'ele' in self.to_apply:
+                df, eleID_SF_branches = self.ele.getIDSF(df, lepton_legs, isCentral, return_variations)
+                all_weights.extend(eleID_SF_branches)
+            if 'puJetID' in self.to_apply:
+                df, puJetID_SF_branches = self.puJetID.getPUJetIDEff(df, isCentral, return_variations)
+                all_weights.extend(puJetID_SF_branches)
+            if 'btagWP' in self.to_apply:
+                df, bTagWP_SF_branches = self.btag.getBTagWPSF(df, isCentral and return_variations, isCentral)
+                all_weights.extend(bTagWP_SF_branches)
+            if 'trgSF' in self.to_apply:
+                df, trg_SF_branches = self.trg.getSF(df, trigger_names, lepton_legs, isCentral and return_variations, isCentral)
+                all_weights.extend(trg_SF_branches)
+            if 'trgEff' in self.to_apply:
+                df, trg_SF_branches = self.trg.getEff(df, trigger_names, offline_legs, self.trigger_dict)
+                all_weights.extend(trg_SF_branches)
         return df, all_weights
 
     def getDenominator(self, df, sources, generator):

--- a/triggersRun3.h
+++ b/triggersRun3.h
@@ -101,19 +101,25 @@ public:
             if (era == "2022_Summer22" || era == "2022_Summer22EE"){// || era == "2023_Summer23" || era == "2023_Summer23BPix"){
                 // muTrgCorrections["Central"]=mutrgcorrections_->at(muon_trg_key);
             // muTrgCorrections["Central"]=mutrgcorrections_->at(muon_trg_key);
-            muTrgCorrections_Mc["Central"]=mutrgcorrections_->at(muon_trg_key_mc);
-            muTrgCorrections_Data["Central"]=mutrgcorrections_->at(muon_trg_key_data);
-            // muTrgCorrections_Mc["Central"]=mutrgcorrections_->at("NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight_MCeff");
-            // muTrgCorrections_Data["Central"]=mutrgcorrections_->at("NUM_IsoMu24_DEN_CutBasedIdTight_and_PFIsoTight_DATAeff");
-            // eleTrgCorrections["Central"]=etrgcorrections_->at(ele_trg_key);
-            tauTrgCorrections["Central"]=tautrgcorrections_->at(tau_trg_key);
-            eleTrgCorrections_Mc["Central"]=etrgcorrections_->at(ele_trg_key_mc);
-            eleTrgCorrections_Data["Central"]=etrgcorrections_->at(ele_trg_key_data);
-            ditauJet_trgCorrections["Central"]=ditauJet_trgcorrections_->at(jet_trg_key);
-            etau_trgCorrections_Mc["Central"]=etau_trgcorrections_->at(ele_trg_key_mc);
-            etau_trgCorrections_Data["Central"]=etau_trgcorrections_->at(ele_trg_key_data);
-            mutau_trgCorrections_Mc["Central"]=mutau_trgcorrections_->at(mutau_trg_key_mc);
-            mutau_trgCorrections_Data["Central"]=mutau_trgcorrections_->at(mutau_trg_key_data);
+
+            // bbWW is still using the SF method (not Eff method)
+            // This means we still need the base key (not mc or data)
+            // To fit in, we will still use mc/data keys (they will be the same)
+            // And we will just load the MC one as the default
+            if (muon_trg_key_mc != "None") muTrgCorrections["Central"]=mutrgcorrections_->at(muon_trg_key_mc);
+            if (ele_trg_key_mc != "None") eleTrgCorrections["Central"]=etrgcorrections_->at(ele_trg_key_mc);
+
+
+            if (muon_trg_key_mc != "None") muTrgCorrections_Mc["Central"]=mutrgcorrections_->at(muon_trg_key_mc);
+            if (muon_trg_key_data != "None") muTrgCorrections_Data["Central"]=mutrgcorrections_->at(muon_trg_key_data);
+            if (tau_trg_key != "None") tauTrgCorrections["Central"]=tautrgcorrections_->at(tau_trg_key);
+            if (ele_trg_key_mc != "None") eleTrgCorrections_Mc["Central"]=etrgcorrections_->at(ele_trg_key_mc);
+            if (ele_trg_key_data != "None") eleTrgCorrections_Data["Central"]=etrgcorrections_->at(ele_trg_key_data);
+            if (tau_trg_key != "None") ditauJet_trgCorrections["Central"]=ditauJet_trgcorrections_->at(jet_trg_key);
+            if (ele_trg_key_mc != "None") etau_trgCorrections_Mc["Central"]=etau_trgcorrections_->at(ele_trg_key_mc);
+            if (ele_trg_key_data != "None") etau_trgCorrections_Data["Central"]=etau_trgcorrections_->at(ele_trg_key_data);
+            if (mutau_trg_key_mc != "None") mutau_trgCorrections_Mc["Central"]=mutau_trgcorrections_->at(mutau_trg_key_mc);
+            if (mutau_trg_key_data != "None") mutau_trgCorrections_Data["Central"]=mutau_trgcorrections_->at(mutau_trg_key_data);
         } else {
            throw std::runtime_error("Era not supported");
         }

--- a/triggersRun3.h
+++ b/triggersRun3.h
@@ -115,7 +115,7 @@ public:
             if (tau_trg_key != "None") tauTrgCorrections["Central"]=tautrgcorrections_->at(tau_trg_key);
             if (ele_trg_key_mc != "None") eleTrgCorrections_Mc["Central"]=etrgcorrections_->at(ele_trg_key_mc);
             if (ele_trg_key_data != "None") eleTrgCorrections_Data["Central"]=etrgcorrections_->at(ele_trg_key_data);
-            if (tau_trg_key != "None") ditauJet_trgCorrections["Central"]=ditauJet_trgcorrections_->at(jet_trg_key);
+            if (jet_trg_key != "None") ditauJet_trgCorrections["Central"]=ditauJet_trgcorrections_->at(jet_trg_key);
             if (ele_trg_key_mc != "None") etau_trgCorrections_Mc["Central"]=etau_trgcorrections_->at(ele_trg_key_mc);
             if (ele_trg_key_data != "None") etau_trgCorrections_Data["Central"]=etau_trgcorrections_->at(ele_trg_key_data);
             if (mutau_trg_key_mc != "None") mutau_trgCorrections_Mc["Central"]=mutau_trgcorrections_->at(mutau_trg_key_mc);

--- a/triggersRun3.py
+++ b/triggersRun3.py
@@ -71,14 +71,44 @@ class TrigCorrProducer:
             if (period.endswith('Summer23BPix')):  TrigCorrProducer.year = period.split("_")[0]+"2023PromptD"
             
             # ROOT.gInterpreter.ProcessLine(f"""::correction::TrigCorrProvider::Initialize("{jsonFile_Mu}","{jsonFile_e}", "{jsonFile_Tau}", "{self.muon_trg_dict[period]}","{self.ele_trg_dict['McEff'][period]}", "{self.tau_trg_dict[period]}", "{period}")""")
-            mu_trg_key_mc = self.trigger_dict['singleMu']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
-            mu_trg_key_data = self.trigger_dict['singleMu']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")
-            mutau_trg_key_mc = self.trigger_dict['mutau']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
-            mutau_trg_key_data = self.trigger_dict['mutau']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")
-            ele_trg_key_mc = self.trigger_dict['singleEle']['legs'][0]['jsonTRGcorrection_key'][period].format("Mc")
-            ele_trg_key_data = self.trigger_dict['singleEle']['legs'][0]['jsonTRGcorrection_key'][period].format("Data")
-            tau_trg_key = self.trigger_dict['ditau']['legs'][0]['jsonTRGcorrection_key'][period]
-            jet_trg_key = self.trigger_dict['ditaujet']['legs'][1]['jsonTRGcorrection_key'][period]
+            mu_trg_key_mc, mu_trg_key_data = None, None
+            ele_trg_key_mc, ele_trg_key_data = None, None
+
+            # bbWW uses singleIsoMu and singleEleWpTight names
+            if 'singleIsoMu' in self.trigger_dict.keys():
+                mu_trg_key_mc = self.trigger_dict['singleIsoMu']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
+                mu_trg_key_data = self.trigger_dict['singleIsoMu']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")
+            if 'singleEleWpTight' in self.trigger_dict.keys():
+                ele_trg_key_mc = self.trigger_dict['singleEleWpTight']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
+                ele_trg_key_data = self.trigger_dict['singleEleWpTight']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")
+
+            # Now bbtautau keys
+            mutau_trg_key_mc, mutau_trg_key_data = None, None
+            tau_trg_key = None
+            jet_trg_key = None
+            if 'singleMu' in self.trigger_dict.keys():
+                mu_trg_key_mc = self.trigger_dict['singleMu']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
+                mu_trg_key_data = self.trigger_dict['singleMu']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")
+            if 'singleEle' in self.trigger_dict.keys():
+                ele_trg_key_mc = self.trigger_dict['singleEle']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
+                ele_trg_key_data = self.trigger_dict['singleEle']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")
+            if 'mutau' in self.trigger_dict.keys():
+                mutau_trg_key_mc = self.trigger_dict['mutau']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
+                mutau_trg_key_data = self.trigger_dict['mutau']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")
+            if 'ditau' in self.trigger_dict.keys():
+                tau_trg_key = self.trigger_dict['ditau']['legs'][0]['jsonTRGcorrection_key'][period]
+            if 'ditaujet' in self.trigger_dict.keys():
+                jet_trg_key = self.trigger_dict['ditaujet']['legs'][1]['jsonTRGcorrection_key'][period]
+
+
+            # mu_trg_key_mc = self.trigger_dict['singleMu']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
+            # mu_trg_key_data = self.trigger_dict['singleMu']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")
+            # mutau_trg_key_mc = self.trigger_dict['mutau']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
+            # mutau_trg_key_data = self.trigger_dict['mutau']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")
+            # ele_trg_key_mc = self.trigger_dict['singleEle']['legs'][0]['jsonTRGcorrection_key'][period].format("Mc")
+            # ele_trg_key_data = self.trigger_dict['singleEle']['legs'][0]['jsonTRGcorrection_key'][period].format("Data")
+            # tau_trg_key = self.trigger_dict['ditau']['legs'][0]['jsonTRGcorrection_key'][period]
+            # jet_trg_key = self.trigger_dict['ditaujet']['legs'][1]['jsonTRGcorrection_key'][period]
             ROOT.gInterpreter.ProcessLine(f"""::correction::TrigCorrProvider::Initialize("{jsonFile_Mu}","{jsonFile_e}", "{jsonFile_Tau}", "{jsonFile_TauJet}", "{jsonFile_eTau}", "{jsonFile_muTau}", "{mu_trg_key_mc}", "{mu_trg_key_data}", "{mutau_trg_key_mc}", "{mutau_trg_key_data}","{ele_trg_key_mc}","{ele_trg_key_data}", "{tau_trg_key}", "{jet_trg_key}", "{period}")""")
             print("TriggCorrProducer initialized")
             TrigCorrProducer.initialized = True

--- a/triggersRun3.py
+++ b/triggersRun3.py
@@ -180,11 +180,12 @@ class TrigCorrProducer:
                 legtype_value = None
                 match = re.search(r"Leg::(\w+)", legtype_query.group(0)) if legtype_query else None
                 legtype_value = match.group(1) if match else None
-                legtype_query = legtype_query.group(0) if legtype_query else ""
-                legtype_query = re.sub(r"(Leg::\w+)", r"static_cast<int>(\1)", legtype_query)
+                # legtype_query = legtype_query.group(0) if legtype_query else ""
+                # legtype_query = re.sub(r"(Leg::\w+)", r"static_cast<int>(\1)", legtype_query)
                 for leg_idx, leg_name in enumerate(offline_legs):
                     applyTrgBranch_name = f"{trg_name}_{leg_name}_triggerleg{trg_leg_idx+1}_ApplyTrgSF"
-                    query = legtype_query.format(obj=leg_name)
+                    # query = legtype_query.format(obj=leg_name)
+                    query = trg_leg["offline_obj"]['cut'].format(obj=leg_name)
                     query += f""" && {leg_name}_index >= 0 && HLT_{trg_name} && {leg_name}_HasMatching_{trg_name}"""
                     df = df.Define(applyTrgBranch_name, f"""{query}""")
                     for scale in getScales(None):

--- a/triggersRun3.py
+++ b/triggersRun3.py
@@ -79,8 +79,8 @@ class TrigCorrProducer:
                 mu_trg_key_mc = self.trigger_dict['singleIsoMu']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
                 mu_trg_key_data = self.trigger_dict['singleIsoMu']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")
             if 'singleEleWpTight' in self.trigger_dict.keys():
-                ele_trg_key_mc = self.trigger_dict['singleEleWpTight']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
-                ele_trg_key_data = self.trigger_dict['singleEleWpTight']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")
+                ele_trg_key_mc = self.trigger_dict['singleEleWpTight']['legs'][0]['jsonTRGcorrection_key'][period].format("Mc")
+                ele_trg_key_data = self.trigger_dict['singleEleWpTight']['legs'][0]['jsonTRGcorrection_key'][period].format("Data")
 
             # Now bbtautau keys
             mutau_trg_key_mc, mutau_trg_key_data = None, None
@@ -90,8 +90,8 @@ class TrigCorrProducer:
                 mu_trg_key_mc = self.trigger_dict['singleMu']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
                 mu_trg_key_data = self.trigger_dict['singleMu']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")
             if 'singleEle' in self.trigger_dict.keys():
-                ele_trg_key_mc = self.trigger_dict['singleEle']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
-                ele_trg_key_data = self.trigger_dict['singleEle']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")
+                ele_trg_key_mc = self.trigger_dict['singleEle']['legs'][0]['jsonTRGcorrection_key'][period].format("Mc")
+                ele_trg_key_data = self.trigger_dict['singleEle']['legs'][0]['jsonTRGcorrection_key'][period].format("Data")
             if 'mutau' in self.trigger_dict.keys():
                 mutau_trg_key_mc = self.trigger_dict['mutau']['legs'][0]['jsonTRGcorrection_key'][period].format("MC")
                 mutau_trg_key_data = self.trigger_dict['mutau']['legs'][0]['jsonTRGcorrection_key'][period].format("DATA")


### PR DESCRIPTION
Adds a checker for corrections to apply (previously would crash if corrections list was empty)

Splits the 'trg' correction into 'trgSF' and 'trgEff' -- It seems bbtautau needed Efficiency calculation method while bbww needs the SF calculation

Now will only access the triggers.yaml dict (python side) if the key exists
Now will only access the correctionlib file (cpp side) if the key is not "None" -- passed from python None as a string