### PR TITLE
Updated ScaRe files and hash for smearing

### DIFF
--- a/MuonScaReProvider.h
+++ b/MuonScaReProvider.h
@@ -100,13 +100,7 @@ namespace correction {
 
             // instantiate CB and get random number following the CB
             analysis::CrystalBall cb(mean, sigma, alpha, n);
-            int64_t phi_seed = static_cast<int64_t>((phi / M_PI) * ((1LL << 31) - 1)) & 0xFFF;
-            analysis::SeedSequence seq{static_cast<uint32_t>(evtNumber), static_cast<uint32_t>(lumiNumber), static_cast<uint32_t>(phi_seed)};
-            uint32_t seed;
-            seq.generate(&seed, &seed + 1);
-
-            TRandom3 rnd(seed);
-            double rndm = rnd.Rndm();
+            double rndm = cset->at("RandomSmearing")->evaluate({(int)evtNumber, (int)lumiNumber, phi});
             return cb.invcdf(rndm);
         }
 

--- a/data/MUO/MuonScaRe/Run3-22CDSep23-Summer22-NanoAODv12/muon_scalesmearing.json.gz
+++ b/data/MUO/MuonScaRe/Run3-22CDSep23-Summer22-NanoAODv12/muon_scalesmearing.json.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:92bcdbbcebc87471b2130f096f2e14c056ef5732d40d24b1a2a3a57d8e854f2f
-size 31029
+oid sha256:57b5d59d07ff095bce8d331edf7e4a8eaa0f436d81d868a6fff9af15f9037708
+size 31162

--- a/data/MUO/MuonScaRe/Run3-22EFGSep23-Summer22EE-NanoAODv12/muon_scalesmearing.json.gz
+++ b/data/MUO/MuonScaRe/Run3-22EFGSep23-Summer22EE-NanoAODv12/muon_scalesmearing.json.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:049b9fa6b097c0578f81344492071d1d5ac1e55b3d886a9f18b62ac57a67156d
-size 31037
+oid sha256:ad055a060a7ea2ee773cf2c17161bd3232eb6dc216b10cb74e63bb94e8322fd5
+size 31171

--- a/data/MUO/MuonScaRe/Run3-23CSep23-Summer23-NanoAODv12/muon_scalesmearing.json.gz
+++ b/data/MUO/MuonScaRe/Run3-23CSep23-Summer23-NanoAODv12/muon_scalesmearing.json.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:20d114a8ce443cc5735a475f155cb1c0e00614bb4698e8978536a241e666f6df
-size 31107
+oid sha256:9b6f1b2ad8d920f89d5ad93ecd7f108a25c06bba7f9f46ff74db9af7801c2bee
+size 31243

--- a/data/MUO/MuonScaRe/Run3-23DSep23-Summer23BPix-NanoAODv12/muon_scalesmearing.json.gz
+++ b/data/MUO/MuonScaRe/Run3-23DSep23-Summer23BPix-NanoAODv12/muon_scalesmearing.json.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:0e71f4f49780e0219483a2e3f5f2a2c7e845342494b703341eb36f839e3ab37e
-size 31089
+oid sha256:77a6b265a9e86acc9a3e14d8b81b33bd96ee07d39aa7c0b8d5e57c10921ad950
+size 31223

--- a/data/MUO/MuonScaRe/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/muon_scalesmearing.json.gz
+++ b/data/MUO/MuonScaRe/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/muon_scalesmearing.json.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:09bd0b94b191a1e4376cff761611119aa0b2e56150754eaf3ca3b96b651e1fc1
-size 27923
+oid sha256:e4b1b7d560f1f7e67a4ffdc759235f000258123cb2c71a6d247f437cc033dbf5
+size 28047

--- a/data/MUO/MuonScaRe/Run3-25Prompt-Summer24-NanoAODv15/muon_scalesmearing.json.gz
+++ b/data/MUO/MuonScaRe/Run3-25Prompt-Summer24-NanoAODv15/muon_scalesmearing.json.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:64a48bef6c5a4163fd567b81899561a2dcc9dc72a2dd6ef74689b62515c0a358
+size 18964


### PR DESCRIPTION
Updating the MuonScare files and the get_rndm function, see the [MR on the MuonPOG repo](https://gitlab.cern.ch/cms-muonPOG/muonscarekit/-/merge_requests/10).

Haven't tested all these files yet. Will run this afternoon.