### PR TITLE
updated scare files

### DIFF
--- a/data/MUO/MuonScaRe/Run3-22CDSep23-Summer22-NanoAODv12/muon_scalesmearing.json.gz
+++ b/data/MUO/MuonScaRe/Run3-22CDSep23-Summer22-NanoAODv12/muon_scalesmearing.json.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:57b5d59d07ff095bce8d331edf7e4a8eaa0f436d81d868a6fff9af15f9037708
-size 31162
+oid sha256:969da52d4d8b135a1673d50f5fbc44f9a0cc478feadee0f00fd4ccd144ce7b97
+size 28384

--- a/data/MUO/MuonScaRe/Run3-22EFGSep23-Summer22EE-NanoAODv12/muon_scalesmearing.json.gz
+++ b/data/MUO/MuonScaRe/Run3-22EFGSep23-Summer22EE-NanoAODv12/muon_scalesmearing.json.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:ad055a060a7ea2ee773cf2c17161bd3232eb6dc216b10cb74e63bb94e8322fd5
-size 31171
+oid sha256:6d9d0ee4047f3021feadf5e099237f850d2dce2e0442aef902f723f846daf5f1
+size 28413

--- a/data/MUO/MuonScaRe/Run3-23CSep23-Summer23-NanoAODv12/muon_scalesmearing.json.gz
+++ b/data/MUO/MuonScaRe/Run3-23CSep23-Summer23-NanoAODv12/muon_scalesmearing.json.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:9b6f1b2ad8d920f89d5ad93ecd7f108a25c06bba7f9f46ff74db9af7801c2bee
-size 31243
+oid sha256:f5b847f706d75aa914c923924b9d011d4ff5baec3a27c1067f87d23ed345a9d5
+size 28523

--- a/data/MUO/MuonScaRe/Run3-23DSep23-Summer23BPix-NanoAODv12/muon_scalesmearing.json.gz
+++ b/data/MUO/MuonScaRe/Run3-23DSep23-Summer23BPix-NanoAODv12/muon_scalesmearing.json.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:77a6b265a9e86acc9a3e14d8b81b33bd96ee07d39aa7c0b8d5e57c10921ad950
-size 31223
+oid sha256:59f6a384a86b8627002533b5d8edf4263afb425a8a7604431fb30afb74833d52
+size 28442

--- a/data/MUO/MuonScaRe/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/muon_scalesmearing.json.gz
+++ b/data/MUO/MuonScaRe/Run3-24CDEReprocessingFGHIPrompt-Summer24-NanoAODv15/muon_scalesmearing.json.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e4b1b7d560f1f7e67a4ffdc759235f000258123cb2c71a6d247f437cc033dbf5
-size 28047
+oid sha256:defdfee1ce05afbeae9df502b462bd19127bb34582687bc3f609973d07675f31
+size 28289

--- a/data/MUO/MuonScaRe/Run3-25Prompt-Summer24-NanoAODv15/muon_scalesmearing.json.gz
+++ b/data/MUO/MuonScaRe/Run3-25Prompt-Summer24-NanoAODv15/muon_scalesmearing.json.gz
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:64a48bef6c5a4163fd567b81899561a2dcc9dc72a2dd6ef74689b62515c0a358
-size 18964
+oid sha256:a5f4da43d05232c8333166005774b235f1d4fe368d58b3b3f14cd64fe6e1b60c
+size 28240

--- a/jet.py
+++ b/jet.py
@@ -155,10 +155,12 @@ class JetCorrProducer:
     jec_tag_map_data = {
         "2022_Prompt": ["Winter22Run3_Run{}_V3_DATA"],
         "2022_Summer22": [
-            "Summer22_22Sep2023_Run{}_V3_DATA"
+            # "Summer22_22Sep2023_Run{}_V3_DATA",
+            "Summer22_22Sep2023_V3_DATA"
         ],  # https://cms-jerc.web.cern.ch/Recommendations/#2022-preee
         "2022_Summer22EE": [
-            "Summer22EE_22Sep2023_Run{}_V3_DATA"
+            "Summer22EE_22Sep2023_Run{}_V3_DATA",
+            "Summer22EE_22Sep2023_V3_DATA"
         ],  # https://cms-jerc.web.cern.ch/Recommendations/#2022-postee
         "2023_Summer23BPix": [
             "Summer23BPixPrompt23_Run{}_V3_DATA",
@@ -214,7 +216,7 @@ class JetCorrProducer:
     }
 
     fatjec_tag_map_data = {
-        "2022_Summer22": ["Summer22_22Sep2023_Run{}_V3_DATA"],
+        "2022_Summer22": ["Summer22_22Sep2023_V3_DATA"],# "Summer22_22Sep2023_Run{}_V3_DATA",
         "2023_Summer23BPix": [
             "Summer23BPixPrompt23_Run{}_V3_DATA",
             "Summer23BPixPrompt23_V3_DATA",
@@ -224,7 +226,7 @@ class JetCorrProducer:
             "Summer23Prompt23_Run{}_V3_DATA",
             "Summer23Prompt23_V3_DATA",
         ],  # Summer23Prompt23_V3_DATA should be there (https://cms-jerc.web.cern.ch/Recommendations/#2023) but it does not find any key, so keep v2 for the moment... https://cms-jerc.web.cern.ch/Recommendations/#2023
-        "2022_Summer22EE": ["Summer22EE_22Sep2023_Run{}_V3_DATA"],
+        "2022_Summer22EE": ["Summer22EE_22Sep2023_Run{}_V3_DATA", "Summer22EE_22Sep2023_V3_DATA"],
         "2024_Summer24": [
             "Summer24Prompt24_V2_DATA"
         ],  # https://cms-jerc.web.cern.ch/Recommendations/#2024
@@ -448,11 +450,7 @@ class JetCorrProducer:
             apply_jer = "true" if apply_JER and not self.isData else "false"
             reapply_jec = "true"  # by the time being
             require_run_number = "false"
-            if (
-                self.period == "2023_Summer23"
-                or self.period == "2024_Summer24"
-                or self.period == "2025_Summer24"
-            ) and self.isData:
+            if  self.isData:
                 require_run_number = "true"
             if self.period == "2023_Summer23BPix":
                 require_run_number = "true"
@@ -470,7 +468,7 @@ class JetCorrProducer:
                                                                                                                        {reapply_jec},{require_run_number},run,{wantPhi},{apply_forward_jet_horns_fix},
                                                                                                                        GenJet_pt, Jet_genJetIdx)""",
                 )
-                print(df.Count().GetValue())
+
                 df = df.Define(
                     "FatJet_p4_shifted_map",
                     f"""::correction::JetCorrectionProvider::getGlobal().getShiftedP4(FatJet_pt, FatJet_eta, FatJet_phi, FatJet_mass,
@@ -530,6 +528,7 @@ class JetCorrProducer:
                     f"FatJet_p4_{syst_name}_delta",
                     f"FatJet_p4_{syst_name} - FatJet_p4_{nano}",
                 )
+
 
         return df, source_dict
 

--- a/jet.py
+++ b/jet.py
@@ -126,41 +126,31 @@ class JetCorrProducer:
 
     # maps period to JEC tag
     jec_tag_map_mc = {
-        "2022_Summer22": ["Summer22_22Sep2023_V3_MC"],
         "2022_Prompt": ["Winter22Run3_V3_MC"],
-        "2022_Summer22EE": ["Summer22EE_22Sep2023_V3_MC"],
-        "2023_Summer23BPix": ["Summer23BPixPrompt23_V3_MC"],
-        "2023_Summer23": [
-            "Summer23Prompt23_V2_MC",
-            # "Summer23Prompt23_V3_MC",
-        ],  # Summer23Prompt23_V3_MC should be there (https://cms-jerc.web.cern.ch/Recommendations/#2023-postbpix) but it does not find any key, so keep ALSO v2 for the moment... https://cms-jerc.web.cern.ch/Recommendations/#2023
-        "2024_Summer24": [
-            "Summer24Prompt24_V2_MC"
-        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2024
-        "2025_Summer24": [
-            "Winter25Prompt25_V3_MC"
-        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2025 # tmp patch because 2025_Summer24 does not exist
-        "2025_Winter25": [
-            "Winter25Prompt25_V3_MC"
-        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2025
+        "2022_Summer22": ["Summer22_22Sep2023_V3_MC"], # https://cms-jerc.web.cern.ch/Recommendations/#2022-preee
+        "2022_Summer22EE": ["Summer22EE_22Sep2023_V3_MC"], # https://cms-jerc.web.cern.ch/Recommendations/#2022-postee
+        "2023_Summer23BPix": ["Summer23BPixPrompt23_V3_MC"], # https://cms-jerc.web.cern.ch/Recommendations/#2023-postbpix
+        "2023_Summer23": ["Summer23Prompt23_V3_MC",], # https://cms-jerc.web.cern.ch/Recommendations/#2023-prebpix
+        "2024_Summer24": ["Summer24Prompt24_V2_MC"], # https://cms-jerc.web.cern.ch/Recommendations/#2024
+        "2025_Summer24": ["Winter25Prompt25_V3_MC"], # https://cms-jerc.web.cern.ch/Recommendations/#2025 # tmp patch because 2025_Summer24 does not exist
+        "2025_Winter25": ["Winter25Prompt25_V3_MC"], # https://cms-jerc.web.cern.ch/Recommendations/#2025
     }
 
     # maps period to base tag
     # for DATA: jec_tag = {base_tag}_Run{letters}_V{version}_DATA
     jec_tag_map_data = {
-        "2022_Summer22": ["Summer22_22Sep2023_Run{}_V3_DATA"],
+        "2022_Prompt": ["Winter22Run3_Run{}_V3_DATA"],
+        "2022_Summer22": ["Summer22_22Sep2023_Run{}_V3_DATA"], # https://cms-jerc.web.cern.ch/Recommendations/#2022-preee
+        "2022_Summer22EE": ["Summer22EE_22Sep2023_Run{}_V3_DATA"], # https://cms-jerc.web.cern.ch/Recommendations/#2022-postee
         "2023_Summer23BPix": [
             "Summer23BPixPrompt23_Run{}_V3_DATA",
             "Summer23BPixPrompt23_V3_DATA",
-        ],
-        "2022_Prompt": ["Winter22Run3_Run{}_V3_DATA"],
+        ], # https://cms-jerc.web.cern.ch/Recommendations/#2023-postbpix
         "2023_Summer23": [
-            # "Summer23Prompt23_Run{}_V3_DATA",
-            # "Summer23Prompt23_V3_DATA",
-            "Summer23Prompt23_Run{}_V2_DATA",
-            "Summer23Prompt23_V2_DATA",
-        ],  # Summer23Prompt23_V3 DATA should be there (https://cms-jerc.web.cern.ch/Recommendations/#2023) but it does not find any key, so keep v2 for the moment... https://cms-jerc.web.cern.ch/Recommendations/#2023
-        "2022_Summer22EE": ["Summer22EE_22Sep2023_Run{}_V3_DATA"],
+            "Summer23Prompt23_Run{}_V3_DATA",
+            "Summer23Prompt23_V3_DATA",
+        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2023
+
         "2024_Summer24": [
             "Summer24Prompt24_V2_DATA"
         ],  # https://cms-jerc.web.cern.ch/Recommendations/#2024
@@ -193,8 +183,7 @@ class JetCorrProducer:
         "2022_Summer22EE": ["Summer22EE_22Sep2023_V3_MC"],
         "2023_Summer23BPix": ["Summer23BPixPrompt23_V3_MC"],
         "2023_Summer23": [
-            "Summer23Prompt23_V2_MC",
-            # "Summer23Prompt23_V3_MC",
+            "Summer23Prompt23_V3_MC",
         ],  # Summer23Prompt23_V3_MC should be there (https://cms-jerc.web.cern.ch/Recommendations/#2023) but it does not find any key, so keep v2 for the moment... https://cms-jerc.web.cern.ch/Recommendations/#2023
         "2024_Summer24": [
             "Summer24Prompt24_V2_MC"
@@ -215,10 +204,8 @@ class JetCorrProducer:
         ],
         "2022_Prompt": ["Winter22Run3_Run{}_V3_DATA"],
         "2023_Summer23": [
-            "Summer23Prompt23_Run{}_V2_DATA",
-            "Summer23Prompt23_V2_DATA",
-            # "Summer23Prompt23_Run{}_V3_DATA",
-            # "Summer23Prompt23_V3_DATA",
+            "Summer23Prompt23_Run{}_V3_DATA",
+            "Summer23Prompt23_V3_DATA",
         ],  # Summer23Prompt23_V3_DATA should be there (https://cms-jerc.web.cern.ch/Recommendations/#2023) but it does not find any key, so keep v2 for the moment... https://cms-jerc.web.cern.ch/Recommendations/#2023
         "2022_Summer22EE": ["Summer22EE_22Sep2023_Run{}_V3_DATA"],
         "2024_Summer24": [

--- a/jet.py
+++ b/jet.py
@@ -127,30 +127,47 @@ class JetCorrProducer:
     # maps period to JEC tag
     jec_tag_map_mc = {
         "2022_Prompt": ["Winter22Run3_V3_MC"],
-        "2022_Summer22": ["Summer22_22Sep2023_V3_MC"], # https://cms-jerc.web.cern.ch/Recommendations/#2022-preee
-        "2022_Summer22EE": ["Summer22EE_22Sep2023_V3_MC"], # https://cms-jerc.web.cern.ch/Recommendations/#2022-postee
-        "2023_Summer23BPix": ["Summer23BPixPrompt23_V3_MC"], # https://cms-jerc.web.cern.ch/Recommendations/#2023-postbpix
-        "2023_Summer23": ["Summer23Prompt23_V3_MC",], # https://cms-jerc.web.cern.ch/Recommendations/#2023-prebpix
-        "2024_Summer24": ["Summer24Prompt24_V2_MC"], # https://cms-jerc.web.cern.ch/Recommendations/#2024
-        "2025_Summer24": ["Winter25Prompt25_V3_MC"], # https://cms-jerc.web.cern.ch/Recommendations/#2025 # tmp patch because 2025_Summer24 does not exist
-        "2025_Winter25": ["Winter25Prompt25_V3_MC"], # https://cms-jerc.web.cern.ch/Recommendations/#2025
+        "2022_Summer22": [
+            "Summer22_22Sep2023_V3_MC"
+        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2022-preee
+        "2022_Summer22EE": [
+            "Summer22EE_22Sep2023_V3_MC"
+        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2022-postee
+        "2023_Summer23BPix": [
+            "Summer23BPixPrompt23_V3_MC"
+        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2023-postbpix
+        "2023_Summer23": [
+            "Summer23Prompt23_V3_MC",
+        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2023-prebpix
+        "2024_Summer24": [
+            "Summer24Prompt24_V2_MC"
+        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2024
+        "2025_Summer24": [
+            "Winter25Prompt25_V3_MC"
+        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2025 # tmp patch because 2025_Summer24 does not exist
+        "2025_Winter25": [
+            "Winter25Prompt25_V3_MC"
+        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2025
     }
 
     # maps period to base tag
     # for DATA: jec_tag = {base_tag}_Run{letters}_V{version}_DATA
     jec_tag_map_data = {
         "2022_Prompt": ["Winter22Run3_Run{}_V3_DATA"],
-        "2022_Summer22": ["Summer22_22Sep2023_Run{}_V3_DATA"], # https://cms-jerc.web.cern.ch/Recommendations/#2022-preee
-        "2022_Summer22EE": ["Summer22EE_22Sep2023_Run{}_V3_DATA"], # https://cms-jerc.web.cern.ch/Recommendations/#2022-postee
+        "2022_Summer22": [
+            "Summer22_22Sep2023_Run{}_V3_DATA"
+        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2022-preee
+        "2022_Summer22EE": [
+            "Summer22EE_22Sep2023_Run{}_V3_DATA"
+        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2022-postee
         "2023_Summer23BPix": [
             "Summer23BPixPrompt23_Run{}_V3_DATA",
             "Summer23BPixPrompt23_V3_DATA",
-        ], # https://cms-jerc.web.cern.ch/Recommendations/#2023-postbpix
+        ],  # https://cms-jerc.web.cern.ch/Recommendations/#2023-postbpix
         "2023_Summer23": [
             "Summer23Prompt23_Run{}_V3_DATA",
             "Summer23Prompt23_V3_DATA",
         ],  # https://cms-jerc.web.cern.ch/Recommendations/#2023
-
         "2024_Summer24": [
             "Summer24Prompt24_V2_DATA"
         ],  # https://cms-jerc.web.cern.ch/Recommendations/#2024

--- a/jet.py
+++ b/jet.py
@@ -160,7 +160,7 @@ class JetCorrProducer:
         ],  # https://cms-jerc.web.cern.ch/Recommendations/#2022-preee
         "2022_Summer22EE": [
             "Summer22EE_22Sep2023_Run{}_V3_DATA",
-            "Summer22EE_22Sep2023_V3_DATA"
+            "Summer22EE_22Sep2023_V3_DATA",
         ],  # https://cms-jerc.web.cern.ch/Recommendations/#2022-postee
         "2023_Summer23BPix": [
             "Summer23BPixPrompt23_Run{}_V3_DATA",
@@ -216,7 +216,9 @@ class JetCorrProducer:
     }
 
     fatjec_tag_map_data = {
-        "2022_Summer22": ["Summer22_22Sep2023_V3_DATA"],# "Summer22_22Sep2023_Run{}_V3_DATA",
+        "2022_Summer22": [
+            "Summer22_22Sep2023_V3_DATA"
+        ],  # "Summer22_22Sep2023_Run{}_V3_DATA",
         "2023_Summer23BPix": [
             "Summer23BPixPrompt23_Run{}_V3_DATA",
             "Summer23BPixPrompt23_V3_DATA",
@@ -226,7 +228,10 @@ class JetCorrProducer:
             "Summer23Prompt23_Run{}_V3_DATA",
             "Summer23Prompt23_V3_DATA",
         ],  # Summer23Prompt23_V3_DATA should be there (https://cms-jerc.web.cern.ch/Recommendations/#2023) but it does not find any key, so keep v2 for the moment... https://cms-jerc.web.cern.ch/Recommendations/#2023
-        "2022_Summer22EE": ["Summer22EE_22Sep2023_Run{}_V3_DATA", "Summer22EE_22Sep2023_V3_DATA"],
+        "2022_Summer22EE": [
+            "Summer22EE_22Sep2023_Run{}_V3_DATA",
+            "Summer22EE_22Sep2023_V3_DATA",
+        ],
         "2024_Summer24": [
             "Summer24Prompt24_V2_DATA"
         ],  # https://cms-jerc.web.cern.ch/Recommendations/#2024
@@ -450,7 +455,7 @@ class JetCorrProducer:
             apply_jer = "true" if apply_JER and not self.isData else "false"
             reapply_jec = "true"  # by the time being
             require_run_number = "false"
-            if  self.isData:
+            if self.isData:
                 require_run_number = "true"
             if self.period == "2023_Summer23BPix":
                 require_run_number = "true"
@@ -528,7 +533,6 @@ class JetCorrProducer:
                     f"FatJet_p4_{syst_name}_delta",
                     f"FatJet_p4_{syst_name} - FatJet_p4_{nano}",
                 )
-
 
         return df, source_dict
 


### PR DESCRIPTION
This PR is intended to include new ScaRe files produced. They have **not** only copied from the folder provided by Filippo (```/afs/cern.ch/user/f/ferrico/cmsonly/JSON_VXBS/*/schemaV2.json```)
but during the latest [MR](https://gitlab.cern.ch/cms-muonPOG/muonscarekit/-/merge_requests/10/diffs#e97f36a1135c1186c8778ca1598584b898c78bdd) in MuonScaRe kit, a new parameter should be added (```RandomSmearing```). 
Since these files do not contain it, the lines to be added have been included manually - checked also with @giorgiopizz whose is the author of the MR.

This PR will include also a change in JERC tag as for 2023 and 2023BPix the files have been updated on Apr 13th.  

