### PR TITLE
Rework process-dependent corrections

### DIFF
--- a/Corrections.py
+++ b/Corrections.py
@@ -107,6 +107,8 @@ class Corrections:
                 if stage not in corr_stages:
                     continue
                 if corr_name not in self.to_apply:
+                    if "processes" in corr_params and process_name not in corr_params["processes"]:
+                        continue
                     self.to_apply[corr_name] = corr_params
                     correction_origins[corr_name] = cfg_name
                 else:

--- a/Corrections.py
+++ b/Corrections.py
@@ -157,6 +157,7 @@ class Corrections:
         self.btag_ = None
         self.pu_ = None
         self.dy_hhbbtautau_ = None
+        self.dy_hhbbww_ = None
         self.mu_ = None
         self.muScaRe_ = None
         self.ele_ = None
@@ -201,6 +202,15 @@ class Corrections:
                 dy_hbbtautau_corr_type, era=self.period
             )
         return self.dy_hhbbtautau_
+
+    @property
+    def dy_hhbbww(self):
+        if self.dy_hhbbww_ is None:
+            from .DY_hhbbww import DYbbwwCorrProducer
+
+            dy_hhbbww_corr_type = self.process_cfg.get("dy_hhbbww_corr_type", "default")
+            self.dy_hhbbww_ = DYbbwwCorrProducer(dy_hhbbww_corr_type, era=self.period)
+        return self.dy_hhbbww_
 
     @property
     def Vpt(self):
@@ -529,6 +539,15 @@ class Corrections:
             )
 
             all_weights.extend(dy_branches)
+
+        if "dy_hhbbww" in self.to_apply:
+            df, dy_bbww_branches = self.dy_hhbbww.getWeight(
+                df,
+                return_variations=return_variations and isCentral,
+                return_list_of_branches=True,
+            )
+
+            all_weights.extend(dy_bbww_branches)
 
         if "base" in self.to_apply:
             for (

--- a/Corrections.py
+++ b/Corrections.py
@@ -107,7 +107,10 @@ class Corrections:
                 if stage not in corr_stages:
                     continue
                 if corr_name not in self.to_apply:
-                    if "processes" in corr_params and process_name not in corr_params["processes"]:
+                    if (
+                        "processes" in corr_params
+                        and process_name not in corr_params["processes"]
+                    ):
                         continue
                     self.to_apply[corr_name] = corr_params
                     correction_origins[corr_name] = cfg_name

--- a/Corrections.py
+++ b/Corrections.py
@@ -192,14 +192,11 @@ class Corrections:
         if self.dy_hhbbtautau_ is None:
             from .DY_hhbbtautau import DYbbtautauCorrProducer
 
-            dy_hbbtautau_corr_type = self.process_cfg.get(
-                "dy_hbbtautau_corr_type", "default"
-            )
-            # self.dy_hhbbtautau_ = DYbbtautauCorrProducer(
-            #     self.to_apply["dy_hhbbtautau"]["type"], era=self.period
-            # )
+            apply_this_proc = self.process_name in self.to_apply.get(
+                "dy_hhbbtautau", {}
+            ).get("processes", [])
             self.dy_hhbbtautau_ = DYbbtautauCorrProducer(
-                dy_hbbtautau_corr_type, era=self.period
+                apply_this_proc, era=self.period
             )
         return self.dy_hhbbtautau_
 
@@ -208,8 +205,10 @@ class Corrections:
         if self.dy_hhbbww_ is None:
             from .DY_hhbbww import DYbbwwCorrProducer
 
-            dy_hhbbww_corr_type = self.process_cfg.get("dy_hhbbww_corr_type", "default")
-            self.dy_hhbbww_ = DYbbwwCorrProducer(dy_hhbbww_corr_type, era=self.period)
+            apply_this_proc = self.process_name in self.to_apply.get(
+                "dy_hhbbww", {}
+            ).get("processes", [])
+            self.dy_hhbbww_ = DYbbwwCorrProducer(apply_this_proc, era=self.period)
         return self.dy_hhbbww_
 
     @property
@@ -217,9 +216,7 @@ class Corrections:
         if self.Vpt_ is None:
             from .Vpt import VptCorrProducer
 
-            Vpt_corr_type = self.process_cfg.get("Vpt_corr_type", "default")
-            # self.Vpt_ = VptCorrProducer(self.to_apply["Vpt"]["type"], self.period)
-            self.Vpt_ = VptCorrProducer(Vpt_corr_type, self.period)
+            self.Vpt_ = VptCorrProducer(self.to_apply["Vpt"]["type"], self.period)
         return self.Vpt_
 
     @property

--- a/Corrections.py
+++ b/Corrections.py
@@ -197,12 +197,7 @@ class Corrections:
         if self.dy_hhbbtautau_ is None:
             from .DY_hhbbtautau import DYbbtautauCorrProducer
 
-            apply_this_proc = self.process_name in self.to_apply.get(
-                "dy_hhbbtautau", {}
-            ).get("processes", [])
-            self.dy_hhbbtautau_ = DYbbtautauCorrProducer(
-                apply_this_proc, era=self.period
-            )
+            self.dy_hhbbtautau_ = DYbbtautauCorrProducer(era=self.period)
         return self.dy_hhbbtautau_
 
     @property
@@ -210,10 +205,7 @@ class Corrections:
         if self.dy_hhbbww_ is None:
             from .DY_hhbbww import DYbbwwCorrProducer
 
-            apply_this_proc = self.process_name in self.to_apply.get(
-                "dy_hhbbww", {}
-            ).get("processes", [])
-            self.dy_hhbbww_ = DYbbwwCorrProducer(apply_this_proc, era=self.period)
+            self.dy_hhbbww_ = DYbbwwCorrProducer(era=self.period)
         return self.dy_hhbbww_
 
     @property

--- a/Corrections.py
+++ b/Corrections.py
@@ -191,8 +191,14 @@ class Corrections:
         if self.dy_hhbbtautau_ is None:
             from .DY_hhbbtautau import DYbbtautauCorrProducer
 
+            dy_hbbtautau_corr_type = self.process_cfg.get(
+                "dy_hbbtautau_corr_type", "default"
+            )
+            # self.dy_hhbbtautau_ = DYbbtautauCorrProducer(
+            #     self.to_apply["dy_hhbbtautau"]["type"], era=self.period
+            # )
             self.dy_hhbbtautau_ = DYbbtautauCorrProducer(
-                self.to_apply["dy_hhbbtautau"]["type"], era=self.period
+                dy_hbbtautau_corr_type, era=self.period
             )
         return self.dy_hhbbtautau_
 
@@ -201,7 +207,9 @@ class Corrections:
         if self.Vpt_ is None:
             from .Vpt import VptCorrProducer
 
-            self.Vpt_ = VptCorrProducer(self.to_apply["Vpt"]["type"], self.period)
+            Vpt_corr_type = self.process_cfg.get("Vpt_corr_type", "default")
+            # self.Vpt_ = VptCorrProducer(self.to_apply["Vpt"]["type"], self.period)
+            self.Vpt_ = VptCorrProducer(Vpt_corr_type, self.period)
         return self.Vpt_
 
     @property

--- a/DY_hhbbtautau.py
+++ b/DY_hhbbtautau.py
@@ -35,7 +35,7 @@ class DYbbtautauCorrProducer:
 
     def __init__(
         self,
-        sampleType,
+        apply_this_proc,
         era,
         *,
         njets_branch="nJet",
@@ -46,10 +46,7 @@ class DYbbtautauCorrProducer:
     ):
         self.era = era
         self.valid = valid
-        if sampleType == "DY":
-            self.isDY = True
-        else:
-            self.isDY = False
+        self.apply_this_proc = apply_this_proc
 
         if self.era not in self.era_map:
             raise RuntimeError(
@@ -118,7 +115,7 @@ class DYbbtautauCorrProducer:
             branch_name = (
                 "weight_dy_central" if syst == "nominal" else f"weight_dy_{syst}"
             )
-            if self.isDY:
+            if self.apply_this_proc:
                 df = df.Define(
                     branch_name,
                     f"""static_cast<float>(

--- a/DY_hhbbtautau.py
+++ b/DY_hhbbtautau.py
@@ -35,7 +35,6 @@ class DYbbtautauCorrProducer:
 
     def __init__(
         self,
-        apply_this_proc,
         era,
         *,
         njets_branch="nJet",
@@ -46,7 +45,6 @@ class DYbbtautauCorrProducer:
     ):
         self.era = era
         self.valid = valid
-        self.apply_this_proc = apply_this_proc
 
         if self.era not in self.era_map:
             raise RuntimeError(
@@ -115,22 +113,19 @@ class DYbbtautauCorrProducer:
             branch_name = (
                 "weight_dy_central" if syst == "nominal" else f"weight_dy_{syst}"
             )
-            if self.apply_this_proc:
-                df = df.Define(
-                    branch_name,
-                    f"""static_cast<float>(
-                        ::correction::DYbbtautauCorrProvider::getGlobal().getWeight(
-                            \"{self.era_map[self.era]}\",
-                            static_cast<int>({self.njets_branch}),
-                            static_cast<int>({self.ntags_branch}),
-                            static_cast<float>({self.pt_ll_gen}),
-                            \"{syst}\",
-                            {valid_expr}
-                        )
-                    )""",
-                )
-            else:
-                df = df.Define(branch_name, f"""1.f""")
+            df = df.Define(
+                branch_name,
+                f"""static_cast<float>(
+                    ::correction::DYbbtautauCorrProvider::getGlobal().getWeight(
+                        \"{self.era_map[self.era]}\",
+                        static_cast<int>({self.njets_branch}),
+                        static_cast<int>({self.ntags_branch}),
+                        static_cast<float>({self.pt_ll_gen}),
+                        \"{syst}\",
+                        {valid_expr}
+                    )
+                )""",
+            )
 
             branches.append(branch_name)
 

--- a/DY_hhbbww.h
+++ b/DY_hhbbww.h
@@ -18,7 +18,7 @@ namespace correction {
                          int njets,
                          float pt_ll,
                          const std::string& syst,
-                         bool isValid) const {
+                         ) const {
             const float ptll = pt_ll;
             static constexpr int kMinNJets = 2;
 
@@ -26,14 +26,10 @@ namespace correction {
 
             double weight = 1.0;
 
-            if (!isValid) {
+            if (njets < kMinNJets) {
                 weight = 1.0;
             } else {
-                if (njets < kMinNJets) {
-                    weight = 1.0;
-                } else {
-                    weight = safeEvaluate(dy_hhbbww_Weight_, era, std::min(njets, MaxJets), ptll, syst);
-                }
+                weight = safeEvaluate(dy_hhbbww_Weight_, era, std::min(njets, MaxJets), ptll, syst);
             }
             return weight;
         }

--- a/DY_hhbbww.h
+++ b/DY_hhbbww.h
@@ -17,19 +17,16 @@ namespace correction {
         double getWeight(const std::string& era,
                          int njets,
                          float pt_ll,
-                         const std::string& syst,
-                         ) const {
-            const float ptll = pt_ll;
+                         const std::string& syst) const {
             static constexpr int kMinNJets = 2;
-
-            const int MaxJets = 10;
+            static constexpr int MaxJets = 10;
 
             double weight = 1.0;
 
             if (njets < kMinNJets) {
                 weight = 1.0;
             } else {
-                weight = safeEvaluate(dy_hhbbww_Weight_, era, std::min(njets, MaxJets), ptll, syst);
+                weight = safeEvaluate(dy_hhbbww_Weight_, era, std::min(njets, MaxJets), pt_ll, syst);
             }
             return weight;
         }

--- a/DY_hhbbww.h
+++ b/DY_hhbbww.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <cmath>
+#include <iostream>
+
+#include "correction.h"
+#include "corrections.h"
+
+namespace correction {
+
+    class DYbbwwCorrProvider : public CorrectionsBase<DYbbwwCorrProvider> {
+      public:
+        explicit DYbbwwCorrProvider(const std::string& fileName)
+            : corrections_(CorrectionSet::from_file(fileName)), dy_hhbbww_Weight_(corrections_->at("dy_correction_weight")) {}
+
+        // template <typename LV1, typename LV2>
+        double getWeight(const std::string& era,
+                         int njets,
+                         float pt_ll,
+                         const std::string& syst,
+                         bool isValid) const {
+            const float ptll = pt_ll;
+            static constexpr int kMinNJets = 2;
+
+            const int MaxJets = 10;
+
+            double weight = 1.0;
+
+            if (!isValid) {
+                weight = 1.0;
+            } else {
+                if (njets < kMinNJets) {
+                    weight = 1.0;
+                } else {
+                    weight = safeEvaluate(dy_hhbbww_Weight_, era, std::min(njets, MaxJets), ptll, syst);
+                }
+            }
+            return weight;
+        }
+
+      private:
+        std::unique_ptr<CorrectionSet> corrections_;
+        Correction::Ref dy_hhbbww_Weight_;
+    };
+
+}  // namespace correction

--- a/DY_hhbbww.py
+++ b/DY_hhbbww.py
@@ -91,7 +91,7 @@ class DYbbwwCorrProducer:
                         \"{self.era_map[self.era]}\",
                         static_cast<int>({self.njets_branch}),
                         static_cast<float>({self.pt_ll}),
-                        \"{syst}\",
+                        \"{syst}\"
                     )
                 )""",
             )

--- a/DY_hhbbww.py
+++ b/DY_hhbbww.py
@@ -23,11 +23,9 @@ class DYbbwwCorrProducer:
         *,
         njets_branch="nJet",
         pt_ll="pt_lep1_lep2",
-        valid="valid",
         variations=None,
     ):
         self.era = era
-        self.valid = valid
 
         if self.era not in self.era_map:
             raise RuntimeError(
@@ -67,29 +65,18 @@ class DYbbwwCorrProducer:
             )
             DYbbwwCorrProducer.initialized = True
 
-    def _valid_expr(self):
-        if isinstance(self.valid, bool):
-            return "true" if self.valid else "false"
-        return f"static_cast<bool>({self.valid})"
-
     def getWeight(
         self,
         df,
         return_variations=True,
         return_list_of_branches=False,
-        enabled=True,
     ):
-        if not enabled:
-            if return_list_of_branches:
-                return df, []
-            return df
 
         systs = ["nominal"]
         if return_variations:
             systs += self.variations
 
         branches = []
-        valid_expr = self._valid_expr()
 
         for syst in systs:
             branch_name = (
@@ -105,7 +92,6 @@ class DYbbwwCorrProducer:
                         static_cast<int>({self.njets_branch}),
                         static_cast<float>({self.pt_ll}),
                         \"{syst}\",
-                        {valid_expr}
                     )
                 )""",
             )

--- a/DY_hhbbww.py
+++ b/DY_hhbbww.py
@@ -19,7 +19,7 @@ class DYbbwwCorrProducer:
 
     def __init__(
         self,
-        sampleType,
+        apply_this_proc,
         era,
         *,
         njets_branch="nJet",
@@ -29,10 +29,7 @@ class DYbbwwCorrProducer:
     ):
         self.era = era
         self.valid = valid
-        if sampleType == "DY":
-            self.isDY = True
-        else:
-            self.isDY = False
+        self.apply_this_proc = apply_this_proc
 
         if self.era not in self.era_map:
             raise RuntimeError(
@@ -102,7 +99,7 @@ class DYbbwwCorrProducer:
                 if syst == "nominal"
                 else f"weight_dy_hhbbww_{syst}"
             )
-            if self.isDY:
+            if self.apply_this_proc:
                 df = df.Define(
                     branch_name,
                     f"""static_cast<float>(

--- a/DY_hhbbww.py
+++ b/DY_hhbbww.py
@@ -19,7 +19,6 @@ class DYbbwwCorrProducer:
 
     def __init__(
         self,
-        apply_this_proc,
         era,
         *,
         njets_branch="nJet",
@@ -29,7 +28,6 @@ class DYbbwwCorrProducer:
     ):
         self.era = era
         self.valid = valid
-        self.apply_this_proc = apply_this_proc
 
         if self.era not in self.era_map:
             raise RuntimeError(
@@ -99,21 +97,18 @@ class DYbbwwCorrProducer:
                 if syst == "nominal"
                 else f"weight_dy_hhbbww_{syst}"
             )
-            if self.apply_this_proc:
-                df = df.Define(
-                    branch_name,
-                    f"""static_cast<float>(
-                        ::correction::DYbbwwCorrProvider::getGlobal().getWeight(
-                            \"{self.era_map[self.era]}\",
-                            static_cast<int>({self.njets_branch}),
-                            static_cast<float>({self.pt_ll}),
-                            \"{syst}\",
-                            {valid_expr}
-                        )
-                    )""",
-                )
-            else:
-                df = df.Define(branch_name, f"""1.f""")
+            df = df.Define(
+                branch_name,
+                f"""static_cast<float>(
+                    ::correction::DYbbwwCorrProvider::getGlobal().getWeight(
+                        \"{self.era_map[self.era]}\",
+                        static_cast<int>({self.njets_branch}),
+                        static_cast<float>({self.pt_ll}),
+                        \"{syst}\",
+                        {valid_expr}
+                    )
+                )""",
+            )
 
             branches.append(branch_name)
 

--- a/DY_hhbbww.py
+++ b/DY_hhbbww.py
@@ -103,7 +103,6 @@ class DYbbwwCorrProducer:
                 else f"weight_dy_hhbbww_{syst}"
             )
             if self.isDY:
-                print(f"Hey this is DY, filling a branch {branch_name}")
                 df = df.Define(
                     branch_name,
                     f"""static_cast<float>(

--- a/DY_hhbbww.py
+++ b/DY_hhbbww.py
@@ -1,0 +1,126 @@
+import os
+import ROOT
+from .CorrectionsCore import *
+
+
+class DYbbwwCorrProducer:
+    JsonPath = "Corrections/data/DY_corr_hhbbww/dy_correction_weight.json.gz"
+    initialized = False
+
+    era_map = {
+        "Run3_2022": "2022_2022EE_2023_2023BPix",
+        "Run3_2022EE": "2022_2022EE_2023_2023BPix",
+        "Run3_2023": "2022_2022EE_2023_2023BPix",
+        "Run3_2023BPix": "2022_2022EE_2023_2023BPix",
+        "Run3_2024": "2022_2022EE_2023_2023BPix",  # Different file for 2024, not implemented yet
+    }
+
+    default_variations = []
+
+    def __init__(
+        self,
+        sampleType,
+        era,
+        *,
+        njets_branch="nJet",
+        pt_ll="pt_lep1_lep2",
+        valid="valid",
+        variations=None,
+    ):
+        self.era = era
+        self.valid = valid
+        if sampleType == "DY":
+            self.isDY = True
+        else:
+            self.isDY = False
+
+        if self.era not in self.era_map:
+            raise RuntimeError(
+                f"DYbbwwCorrProducer: unsupported era '{self.era}'. "
+                f"Supported eras: {list(self.era_map.keys())}"
+            )
+
+        analysis_path = os.environ.get("ANALYSIS_PATH")
+        if analysis_path is None:
+            raise RuntimeError(
+                "DYbbwwCorrProducer: ANALYSIS_PATH is not set. "
+                "Cannot resolve DY correction JSON path."
+            )
+
+        if os.path.isabs(self.JsonPath):
+            self.json_path = self.JsonPath
+        else:
+            self.json_path = os.path.join(analysis_path, self.JsonPath)
+
+        if not os.path.exists(self.json_path):
+            raise FileNotFoundError(
+                f"DYbbwwCorrProducer: DY correction JSON not found: {self.json_path}"
+            )
+
+        self.njets_branch = njets_branch
+        self.pt_ll = pt_ll
+        self.variations = list(
+            self.default_variations if variations is None else variations
+        )
+
+        if not DYbbwwCorrProducer.initialized:
+            headers_dir = os.path.dirname(os.path.abspath(__file__))
+            header_path = os.path.join(headers_dir, "DY_hhbbww.h")
+            ROOT.gInterpreter.Declare(f'#include "{header_path}"')
+            ROOT.gInterpreter.ProcessLine(
+                f'::correction::DYbbwwCorrProvider::Initialize("{self.json_path}")'
+            )
+            DYbbwwCorrProducer.initialized = True
+
+    def _valid_expr(self):
+        if isinstance(self.valid, bool):
+            return "true" if self.valid else "false"
+        return f"static_cast<bool>({self.valid})"
+
+    def getWeight(
+        self,
+        df,
+        return_variations=True,
+        return_list_of_branches=False,
+        enabled=True,
+    ):
+        if not enabled:
+            if return_list_of_branches:
+                return df, []
+            return df
+
+        systs = ["nominal"]
+        if return_variations:
+            systs += self.variations
+
+        branches = []
+        valid_expr = self._valid_expr()
+
+        for syst in systs:
+            branch_name = (
+                "weight_dy_hhbbww_central"
+                if syst == "nominal"
+                else f"weight_dy_hhbbww_{syst}"
+            )
+            if self.isDY:
+                print(f"Hey this is DY, filling a branch {branch_name}")
+                df = df.Define(
+                    branch_name,
+                    f"""static_cast<float>(
+                        ::correction::DYbbwwCorrProvider::getGlobal().getWeight(
+                            \"{self.era_map[self.era]}\",
+                            static_cast<int>({self.njets_branch}),
+                            static_cast<float>({self.pt_ll}),
+                            \"{syst}\",
+                            {valid_expr}
+                        )
+                    )""",
+                )
+            else:
+                df = df.Define(branch_name, f"""1.f""")
+
+            branches.append(branch_name)
+
+        if return_list_of_branches:
+            return df, branches
+        return df

--- a/data/DY_corr_hhbbww/dy_correction_weight.json.gz
+++ b/data/DY_corr_hhbbww/dy_correction_weight.json.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44323c3256b46e6bd379bf7627d266f6b8b30db89675616952799bba6e21b54a
+size 1065


### PR DESCRIPTION
In previous implementation of DY corrections for both Vpt and for bbtautau, the method was to add the corrections onto the ```HH_**/config/Run3_2022/processes.yaml``` file, where each dataset would have specific corrections listed (see https://github.com/cms-flaf/HH_bbtautau/blob/d51d0082e3faf4177f5d7e07d97f7fb4217a4d43/config/Run3_2022/processes.yaml#L18-L21)

There are 2 problems with this:
1. It is disgusting code.
2. This correction will only run for processes that list it, meaning the weight branches do not exist for non-DY processes.

The problem was jumped around by having an isDY check in the analysis code (see https://github.com/cms-flaf/HH_bbtautau/blob/d51d0082e3faf4177f5d7e07d97f7fb4217a4d43/Analysis/hh_bbtautau.py#L268)

This is even more disgusting. And there was already a default value of 1.0 for the branch when sample type was not DY, but we never passed non-DY processes to it!

My fix proposal is to run the DY corrections for everything like every other correction, and index which processes need it inside the ```HH_**/config/Run3_2022/processes.yaml``` files through a new key system (see https://github.com/aebid/HH_bbWW/blob/de5da381dfb8ebcd288bcdf16d15aa5fd43e886a/config/Run3_2022/processes.yaml#L13-L14).

I think this is more clear and future proof as more dataset-specific corrections come up. With loading the correction object through this key and a default value, we can easily specify which datasets need these types of corrections.