### PR TITLE
Define stitching processor variables before xs/denominator (FLAF #169)

### DIFF
--- a/Corrections.py
+++ b/Corrections.py
@@ -477,6 +477,19 @@ class Corrections:
                             )
         return df, syst_dict
 
+    def prepareStitchingVariables(self, df):
+        # Define any columns the stitching processors select on (e.g. a gen-level
+        # decay-mode or dilepton mass) once, before the cross-section and denominator
+        # expressions reference them. Processors that only use native nanoAOD branches
+        # (e.g. LHE_Vpt/LHE_NpNLO) leave the frame unchanged.
+        prepared = set()
+        for p_name in self.xs_denom_processors.values():
+            if p_name in prepared:
+                continue
+            prepared.add(p_name)
+            df = self.all_processors[p_name].onAnaTuple_prepareDataFrame(df)
+        return df
+
     def defineCrossSection(self, df, crossSectionBranchBase):
         branches = []
         if len(self.xs_denom_processors) == 0:
@@ -543,6 +556,9 @@ class Corrections:
             lumi = self.global_params["luminosity"]
             df = df.Define(lumi_weight_name, f"float({lumi})")
             all_weights.append(lumi_weight_name)
+
+        if len(self.xs_denom_processors) > 0:
+            df = self.prepareStitchingVariables(df)
 
         crossSectionBranchBase = "weight_xs"
         if "xs" in self.to_apply:

--- a/Corrections.py
+++ b/Corrections.py
@@ -557,7 +557,10 @@ class Corrections:
             df = df.Define(lumi_weight_name, f"float({lumi})")
             all_weights.append(lumi_weight_name)
 
-        if len(self.xs_denom_processors) > 0:
+        # xs_denom_processors only exists when "xs"/"base" normalisation is set up (anaTuple
+        # stage). getNormalisationCorrections is also called at the histogram stage (via the
+        # analysis histTupleDef) where it is absent, so guard with getattr.
+        if getattr(self, "xs_denom_processors", None):
             df = self.prepareStitchingVariables(df)
 
         crossSectionBranchBase = "weight_xs"


### PR DESCRIPTION
Companion to cms-flaf/FLAF#289 (dataset stitching, #169).

`MCStitcher` subclasses that select on a **derived** gen-level column (TT decay mode, LHE
dilepton flavor/mass, Z→ττ filter) crash at the anaTuple stage: `getNormalisationCorrections`
builds the cross-section / denominator expressions without first defining those columns. The
built-in DY Vpt/NpNLO stitch only worked because `LHE_Vpt`/`LHE_NpNLO` are native branches.

Adds `prepareStitchingVariables()`, which calls each stitching processor's
`onAnaTuple_prepareDataFrame` once before the xs/denominator loop. Verified by real anaTuple
runs of the new TT and DY→ττ stitchers (`weight_xs` now defines correctly and the event loop
completes). **Merge together with the FLAF PR.**
